### PR TITLE
site.mk: remove gluon-next-node

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -21,7 +21,6 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-wifi-config \
 	gluon-luci-private-wifi \
 	gluon-mesh-vpn-fastd \
-	gluon-next-node \
 	gluon-radvd \
 	gluon-respondd \
 	gluon-setup-mode \


### PR DESCRIPTION
Package is obsolete in the master of gluon