### PR TITLE
Use 40 Mhz channel width for 5Ghz wifi

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -42,6 +42,7 @@
 
   wifi5 = {
     channel = 44,
+    htmode = 'HT40+',
     ap = {
       ssid = 'Freifunk',
     },


### PR DESCRIPTION
Allows better bandwidths in the not so congested 5Ghz area